### PR TITLE
publishing dist files only instead of sources and dist

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,0 @@
-dashjs/
-toolkit
-bridge
-.ruby-version
-dist/bundle

--- a/circle.yml
+++ b/circle.yml
@@ -89,15 +89,20 @@ deployment:
             - cp dist/bundle/$DIST_BUNDLE $CIRCLE_ARTIFACTS/$DIST_BUNDLE
             - cp dist/wrapper/$DIST_WRAPPER $CIRCLE_ARTIFACTS/$DIST_WRAPPER
 
-            # Build package.json for the bundle
+            # Build package.json
             - toolkit/build_dist_package.rb --version $(toolkit/current_version.rb)
                                             --main ./$DIST_BUNDLE
                                             --name $BUNDLE_NAME
                                             -o dist/bundle/package.json
 
+            - toolkit/build_dist_package.rb --version $(toolkit/current_version.rb)
+                                            --main ./$DIST_WRAPPER
+                                            --name $WRAPPER_NAME
+                                            -o dist/wrapper/package.json
+
             # Publish
             - npm publish dist/bundle --tag beta
-            - npm publish --tag beta
+            - npm publish dist/wrapper --tag beta
 
             # Upload version
             - toolkit/upload_to_s3.rb --bucket $S3_STAGING_BUCKET
@@ -167,15 +172,20 @@ deployment:
             - cp dist/bundle/$DIST_BUNDLE $CIRCLE_ARTIFACTS/$DIST_BUNDLE
             - cp dist/wrapper/$DIST_WRAPPER $CIRCLE_ARTIFACTS/$DIST_WRAPPER
 
-            # Build package.json for the bundle
+            # Build package.json
             - toolkit/build_dist_package.rb --version $(toolkit/current_version.rb)
                                             --main ./$DIST_BUNDLE
                                             --name $BUNDLE_NAME
                                             -o dist/bundle/package.json
 
+            - toolkit/build_dist_package.rb --version $(toolkit/current_version.rb)
+                                            --main ./$DIST_WRAPPER
+                                            --name $WRAPPER_NAME
+                                            -o dist/wrapper/package.json
+
             # Publish
             - npm publish dist/bundle
-            - npm publish
+            - npm publish dist/wrapper
 
             # Upload version
             - toolkit/upload_to_s3.rb --bucket $S3_PREPROD_BUCKET

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "streamroot-dashjs-p2p-wrapper",
   "description": "Streamroot P2P wrapper for the dash.js media player",
   "version": "1.2.0",
+  "private": true,
   "author": {
     "name": "Streamroot",
     "email": "contact@streamroot.io"


### PR DESCRIPTION
Decided not to publish source files for the wrapper because babel can not transpile sub dependencies.
Done pair programming with Maxime.