### PR TITLE
Fixing dynamic manifest switching

### DIFF
--- a/lib/DashjsInternals.js
+++ b/lib/DashjsInternals.js
@@ -1,5 +1,15 @@
+/**
+* DashjsInternals class
+* This class must be instatiatied only once per each instance of dash.js MediaPlayer.
+* It exposes dash.js private methods for getting access to TimeLineConverter,
+* ManifestModel, Config and Context instances.
+*/
+
 class DashjsInternals {
 
+    /**
+    * @player -- instance of dash.js MediaPlayer
+    */
     constructor(player) {
 
         let getConfig,

--- a/lib/DashjsWrapperPrivate.js
+++ b/lib/DashjsWrapperPrivate.js
@@ -5,6 +5,7 @@ import SegmentView from './SegmentView';
 import FragmentLoaderClassProvider from './FragmentLoaderClassProvider';
 import StreamrootPeerAgentModule from 'streamroot-p2p';
 import MediaPlayerEvents from '../dashjs/src/streaming/MediaPlayerEvents';
+import DashjsInternals from './DashjsInternals';
 
 const INTEGRATION_VERSION = 'v1';
 
@@ -29,6 +30,11 @@ class DashjsWrapperPrivate {
         this._liveDelay = liveDelay;
         this._player.setLiveDelay(liveDelay);
 
+        // This object is for exposing dash.js internals. It does this by
+        // extending dash.js class, that's why it must be instantiated only once
+        // and before creating any other objects
+        this._dashjsInternals = new DashjsInternals(player);
+
         this._player.extend(
             "FragmentLoader",
             new FragmentLoaderClassProvider(this).SRFragmentLoader,
@@ -52,6 +58,10 @@ class DashjsWrapperPrivate {
 
     get player() {
         return this._player;
+    }
+
+    get dashjsInternals() {
+        return this._dashjsInternals;
     }
 
     initialize(manifest) {

--- a/lib/DashjsWrapperPrivate.js
+++ b/lib/DashjsWrapperPrivate.js
@@ -60,14 +60,10 @@ class DashjsWrapperPrivate {
         return this._player;
     }
 
-    get dashjsInternals() {
-        return this._dashjsInternals;
-    }
-
     initialize(manifest) {
         this.updateManifest(manifest);
 
-        let manifestHelper = new ManifestHelper(this);
+        let manifestHelper = new ManifestHelper(this, this._dashjsInternals);
 
         this._playerInterface = new PlayerInterface(
             this._player,

--- a/lib/ManifestHelper.js
+++ b/lib/ManifestHelper.js
@@ -1,21 +1,21 @@
 import TrackView from './TrackView';
 import SegmentsGetter from '../dashjs/src/dash/utils/SegmentsGetter';
 import SegmentsCache from './SegmentsCache';
-import DashjsInternals from './DashjsInternals';
 
 class ManifestHelper {
 
     constructor (wrapper) {
-
         this._wrapper = wrapper;
         let player = this._player = wrapper.player;
-        this._dashjsInternals = new DashjsInternals(player);
         this._segmentsCache = new SegmentsCache(player);
     }
 
-
     get _manifest() {
         return this._wrapper.manifest;
+    }
+
+    get _dashjsInternals() {
+        return this._wrapper.dashjsInternals;
     }
 
     _getSegmentsGetter() {

--- a/lib/ManifestHelper.js
+++ b/lib/ManifestHelper.js
@@ -6,8 +6,11 @@ class ManifestHelper {
 
     constructor (wrapper) {
         this._wrapper = wrapper;
-        let player = this._player = wrapper.player;
-        this._segmentsCache = new SegmentsCache(player);
+        this._segmentsCache = new SegmentsCache(this._player);
+    }
+
+    get _player() {
+        return this._wrapper.player;
     }
 
     get _manifest() {

--- a/lib/ManifestHelper.js
+++ b/lib/ManifestHelper.js
@@ -4,8 +4,9 @@ import SegmentsCache from './SegmentsCache';
 
 class ManifestHelper {
 
-    constructor (wrapper) {
+    constructor (wrapper, dashjsInternals) {
         this._wrapper = wrapper;
+        this._dashjsInternals = dashjsInternals;
         this._segmentsCache = new SegmentsCache(this._player);
     }
 
@@ -15,10 +16,6 @@ class ManifestHelper {
 
     get _manifest() {
         return this._wrapper.manifest;
-    }
-
-    get _dashjsInternals() {
-        return this._wrapper.dashjsInternals;
     }
 
     _getSegmentsGetter() {


### PR DESCRIPTION
Fixes this bug https://www.pivotaltracker.com/story/show/122503851

The reason of the bug: instantiation of an object, that exposes dash.js internals(so we can get access to manifest model and other necessary stuff), became broken -- instead of being instantiated only once per dash.js MediaPlayer instance, it was created each time manifest was changed.

Why it should be instantiated only once per MediaPlayer instance? Because it extends dash.js class, and such extension must happen only once and before`mediaPlayer.initialize()` call.