### PR TITLE
[#128218253] passing context to MediaPlayer

### DIFF
--- a/lib/DashjsBundle.js
+++ b/lib/DashjsBundle.js
@@ -4,9 +4,9 @@ require('../dashjs/all');
 
 import DashjsWrapper from './DashjsWrapper';
 
-function MediaPlayer(p2pConfig) {
+function MediaPlayer(context = {}, p2pConfig) {
     const liveDelay = 30;
-    let player = window.dashjs.MediaPlayer().create();
+    let player = window.dashjs.MediaPlayer(context).create();
 
     new DashjsWrapper(player, p2pConfig, liveDelay);
 
@@ -14,10 +14,10 @@ function MediaPlayer(p2pConfig) {
     return player;
 }
 
-function MediaPlayerFactory() {
+function MediaPlayerFactory(context = {}) {
     return {
         create: function(p2pConfig) {
-            return new MediaPlayer(p2pConfig);
+            return new MediaPlayer(context, p2pConfig);
         }
     };
 }

--- a/lib/DashjsBundle.js
+++ b/lib/DashjsBundle.js
@@ -4,7 +4,7 @@ require('../dashjs/all');
 
 import DashjsWrapper from './DashjsWrapper';
 
-function MediaPlayer(context = {}, p2pConfig) {
+function MediaPlayer(context, p2pConfig) {
     const liveDelay = 30;
     let player = window.dashjs.MediaPlayer(context).create();
 


### PR DESCRIPTION
This PR is required for successful completion of https://www.pivotaltracker.com/story/show/128218253

dash.js allows usage of custom context object in MediaPlayer.
This PR enables this feature in the bundle. The feature is used in https://github.com/streamroot/videojs5-dashjs-p2p-source-handler