### PR TITLE
Keeping console logs

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -147,6 +147,7 @@ deployment:
             - toolkit/update_version.rb
 
             # Changelog
+            - toolkit/update_changelog_with_parent_dep.rb --module-name $TRIGGERED_FROM_MODULE
             - toolkit/bump_current_changelog.rb --version $(toolkit/current_version.rb)
 
             # Keep dev up to date

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "streamroot-dashjs-p2p-wrapper",
   "description": "Streamroot P2P wrapper for the dash.js media player",
-  "version": "1.5.0-beta.0",
+  "version": "1.6.0-beta.0",
   "private": true,
   "author": {
     "name": "Streamroot",

--- a/scripts/dist_bundle.rb
+++ b/scripts/dist_bundle.rb
@@ -17,6 +17,6 @@ def command(cmd)
   puts %x(#{cmd})
 end
 
-command "#{BROWSERIFY} -p browserify-derequire -t [babelify] -s DashjsP2PBundle #{DASHJS_BUNDLE} | #{UGLIFYJS} -m --compress warnings=false,drop_console=true > #{DIST_BUNDLE}"
+command "#{BROWSERIFY} -p browserify-derequire -t [babelify] -s DashjsP2PBundle #{DASHJS_BUNDLE} | #{UGLIFYJS} -m --compress warnings=false > #{DIST_BUNDLE}"
 
 

--- a/scripts/dist_wrapper.rb
+++ b/scripts/dist_wrapper.rb
@@ -17,5 +17,5 @@ def command(cmd)
   puts %x(#{cmd})
 end
 
-command "#{BROWSERIFY} -p browserify-derequire -t [babelify] -s DashjsWrapper #{DASHJS_WRAPPER} | #{UGLIFYJS} -m --compress warnings=false,drop_console=true > #{DIST_WRAPPER}"
+command "#{BROWSERIFY} -p browserify-derequire -t [babelify] -s DashjsWrapper #{DASHJS_WRAPPER} | #{UGLIFYJS} -m --compress warnings=false > #{DIST_WRAPPER}"
 


### PR DESCRIPTION
Removed `--drop-console=true` from `uglifyjs` params, because we need to keep standard dash.js console logging.