### PR TITLE
enabled console log in build files

### DIFF
--- a/scripts/dist_bundle.rb
+++ b/scripts/dist_bundle.rb
@@ -17,6 +17,6 @@ def command(cmd)
   puts %x(#{cmd})
 end
 
-command "#{BROWSERIFY} -p browserify-derequire -t [babelify] -s DashjsP2PBundle #{DASHJS_BUNDLE} | #{UGLIFYJS} -m --compress warnings=false,drop_console=true > #{DIST_BUNDLE}"
+command "#{BROWSERIFY} -p browserify-derequire -t [babelify] -s DashjsP2PBundle #{DASHJS_BUNDLE} | #{UGLIFYJS} -m --compress warnings=false > #{DIST_BUNDLE}"
 
 

--- a/scripts/dist_wrapper.rb
+++ b/scripts/dist_wrapper.rb
@@ -17,5 +17,5 @@ def command(cmd)
   puts %x(#{cmd})
 end
 
-command "#{BROWSERIFY} -p browserify-derequire -t [babelify] -s DashjsWrapper #{DASHJS_WRAPPER} | #{UGLIFYJS} -m --compress warnings=false,drop_console=true > #{DIST_WRAPPER}"
+command "#{BROWSERIFY} -p browserify-derequire -t [babelify] -s DashjsWrapper #{DASHJS_WRAPPER} | #{UGLIFYJS} -m --compress warnings=false > #{DIST_WRAPPER}"
 


### PR DESCRIPTION
Removed `--drop-console=true` from `uglifyjs` params, because we need to keep standard dash.js console logging.