### PR TITLE
Debug improvements

### DIFF
--- a/example/bundle.html
+++ b/example/bundle.html
@@ -21,6 +21,7 @@
         <div>
             <div id="mainfestSelection" />
                 <select id="mpdSelector" name="mpdSelector">
+                    <option value="http://wowza-test.streamroot.io/liveOrigin/sintel-live.smil/manifest.mpd">Streamroot live test stream</option>
                     <option value="http://wowza.streamroot.io/vodOriginSite/tears_of_steel720p.mp4/manifest.mpd">ToS (VoD, 1 video)</option>
                     <option value="http://wowza.streamroot.io/liveorigin/stream4/manifest.mpd">ToS (Live DVR, 1 video)</option>
                     <option value="http://wowza.streamroot.io/liveorigin/Sample-live.smil/manifest.mpd">Sintel (Live DVR, 3 video)</option>

--- a/example/bundle.html
+++ b/example/bundle.html
@@ -10,7 +10,7 @@
         </script>
 
         <!-- streamroot-dash bundle -->
-        <script src="../dist/bundle/dashjs-p2p-bundle.js"></script>
+        <script src="../dist/bundle/dashjs-p2p-bundle.debug.js"></script>
 
         <!-- p2p graphics and peer stats -->
         <script src="http://cdn.streamroot.io/2/scripts/peerStat.js"></script>

--- a/example/bundle.html
+++ b/example/bundle.html
@@ -118,6 +118,12 @@
 
                 var videoElementId = "videoPlayer";
                 var videoElement = document.getElementById(videoElementId);
+
+                videoElement.addEventListener('error', function(ev) {
+                    console.log(ev);
+                    console.log(videoElement.error);
+                });
+
                 var url = urlParams.mpd || mpdSelector.value;
                 var autoStart = true;
                 player.initialize(videoElement, url, autoStart);

--- a/example/bundle.html
+++ b/example/bundle.html
@@ -2,6 +2,13 @@
     <head>
         <title>Bundle example</title>
 
+        <script type="text/javascript">
+            window._MOBILE_ = false;
+            window._ENVIRONMENT_ = 'development';
+            window._DEBUG_ = true;
+            window._TEST_ = false;
+        </script>
+
         <!-- streamroot-dash bundle -->
         <script src="../dist/bundle/dashjs-p2p-bundle.js"></script>
 

--- a/example/wrapper.html
+++ b/example/wrapper.html
@@ -22,6 +22,7 @@
         <div>
             <div id="mainfestSelection" />
                 <select id="mpdSelector" name="mpdSelector">
+                    <option value="http://wowza-test.streamroot.io/liveOrigin/sintel-live.smil/manifest.mpd">Streamroot live test stream</option>
                     <option value="http://wowza.streamroot.io/vodOriginSite/tears_of_steel720p.mp4/manifest.mpd">ToS (VoD, 1 video)</option>
                     <option value="http://wowza.streamroot.io/liveorigin/stream4/manifest.mpd">ToS (Live DVR, 1 video)</option>
                     <option value="http://wowza.streamroot.io/liveorigin/Sample-live.smil/manifest.mpd">Sintel (Live DVR, 3 video)</option>

--- a/example/wrapper.html
+++ b/example/wrapper.html
@@ -2,6 +2,13 @@
     <head>
         <title>Wrapper example</title>
 
+        <script type="text/javascript">
+            window._MOBILE_ = false;
+            window._ENVIRONMENT_ = 'development';
+            window._DEBUG_ = true;
+            window._TEST_ = false;
+        </script>
+
         <!-- streamroot-dash wrapper -->
         <script src="../node_modules/dashjs/dist/dash.all.debug.js"></script>
         <script src="../dist/wrapper/dashjs-p2p-wrapper.js"></script>

--- a/example/wrapper.html
+++ b/example/wrapper.html
@@ -11,7 +11,7 @@
 
         <!-- streamroot-dash wrapper -->
         <script src="../node_modules/dashjs/dist/dash.all.debug.js"></script>
-        <script src="../dist/wrapper/dashjs-p2p-wrapper.js"></script>
+        <script src="../dist/wrapper/dashjs-p2p-wrapper.debug.js"></script>
 
         <!-- p2p graphics and peer stats -->
         <script src="http://cdn.streamroot.io/2/scripts/peerStat.js"></script>

--- a/example/wrapper.html
+++ b/example/wrapper.html
@@ -122,6 +122,12 @@
 
                 var videoElementId = "videoPlayer";
                 var videoElement = document.getElementById(videoElementId);
+
+                videoElement.addEventListener('error', function(ev) {
+                    console.log(ev);
+                    console.log(videoElement.error);
+                });
+
                 var url = urlParams.mpd || mpdSelector.value;
                 var autoStart = true;
                 player.initialize(videoElement, url, autoStart);

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "build": "npm run clean && npm run dashjs && npm run wrapper && npm run bundle"
   },
   "dependencies": {
-    "codem-isoboxer": "^0.2.2",
-    "dashjs": "2.2.0",
+    "codem-isoboxer": "0.2.2",
+    "dashjs": "2.3.0",
     "streamroot-p2p": "^4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
* Allows for using example pages with debug builds produced by compile-watch scripts.
* Allows for using local peer-agent build (needs environment vars in window)
* Allows for logging video decoding and other native media errors
* Adds our Wowza live-stream to the playlists

⚠️  don't merge this before the dash.js-2.3.0 branch

NOTE: it would be better to not have two different builds (debug/non-debug) but to simply set the NODE_ENV var appropriately, for example when I'm in dev mode set it to 'development', and make all builds be "debug" in that case. Avoids having to deal with different paths for each and/or duplicating HTML eventually.