### PR TITLE
Bola metrics fix

### DIFF
--- a/example/bundle.html
+++ b/example/bundle.html
@@ -56,82 +56,22 @@
         <div id="peerStat"/>
 
         <script>
-            (function() {
+            function createPlayer(videoElement, url, params, p2pConfig) {
 
-                var updateIntervalId;
+                var autoStart = parseURLOption(params, "autoStart", true);
+                var enableBOLA = parseURLOption(params, "enableBOLA", false);
 
-                function startUpdate() {
-                    updateIntervalId = setInterval(update, 1000);
-                }
-
-                function stopUpdate() {
-                    clearInterval(updateIntervalId);
-                }
-
-                function update() {
-                    if (player.isReady()) {
-                        document.getElementById("liveDelay").innerHTML = "liveDelay=" + liveDelay;
-                        document.getElementById("bufferLength").innerHTML = "bufferLength=" + player.getBufferLength();
-                    }
-                }
-
-                function getURLParams(url) {
-                    if (!url) {
-                        return {};
-                    }
-
-                    var search = url.substring(1); //removing '?'
-                    var paramValueList = search.split("&");
-                    var params = {};
-                    paramValueList.forEach(function(entry){
-                        var paramValue = entry.split("=");
-                        if (entry) {
-                            params[paramValue[0]] = decodeURIComponent(paramValue[1]);
-                        }
-                    });
-
-                    return params;
-                }
-
-                // manifest selector handler
-                document.getElementById("mpdSelector").onchange = function() {
-                    stopUpdate();
-                    var mpdUrl = document.getElementById("mpdSelector").value;
-                    player.attachSource(mpdUrl);
-                    startUpdate();
-                };
-
-                // quality switch button click handler
-                document.getElementById("videoQualitySwitcher").onclick = function() {
-                    player.setAutoSwitchQualityFor('video', false);
-                    player.setQualityFor('video', document.getElementById("presentationId").value);
-                };
-
-                var p2pConfig = {
-                    streamrootKey: "ry-tguzre2t",
-                    debug: true
-                };
                 var player = DashjsP2PBundle.MediaPlayer().create(p2pConfig);
 
-                var urlParams = getURLParams(document.location.search);
-                player.getDebug().setLogToBrowserConsole(urlParams.dashjsLog != "0");
+                player.getDebug().setLogToBrowserConsole(params.dashjsLog !== "0");
 
-                var videoElementId = "videoPlayer";
-                var videoElement = document.getElementById(videoElementId);
-
-                videoElement.addEventListener('error', function(ev) {
-                    console.log(ev);
-                    console.log(videoElement.error);
-                });
-
-                var url = urlParams.mpd || mpdSelector.value;
-                var autoStart = true;
+                player.enableBufferOccupancyABR(enableBOLA);
                 player.initialize(videoElement, url, autoStart);
 
-                mpdSelector.value = url;
-
-                startUpdate();
-            })();
+                return player;
+            }
         </script>
+        <script src="index.js"></script>
+
     </body>
 </html>

--- a/example/index.js
+++ b/example/index.js
@@ -1,0 +1,76 @@
+var updateIntervalId;
+var player;
+
+function startUpdate() {
+    updateIntervalId = setInterval(update, 1000);
+}
+
+function stopUpdate() {
+    clearInterval(updateIntervalId);
+}
+
+function update() {
+    if (player.isReady()) {
+        document.getElementById("liveDelay").innerHTML = "liveDelay=" + liveDelay;
+        document.getElementById("bufferLength").innerHTML = "bufferLength=" + player.getBufferLength();
+    }
+}
+
+function getURLParams(url) {
+    if (!url) {
+        return {};
+    }
+
+    var search = url.substring(1); //removing '?'
+    var paramValueList = search.split("&");
+    var params = {};
+    paramValueList.forEach(function(entry){
+        var paramValue = entry.split("=");
+        if (entry) {
+            params[paramValue[0]] = decodeURIComponent(paramValue[1]);
+        }
+    });
+
+    return params;
+}
+
+function parseURLOption(params, option, defaultValue) {
+    return !! (params[option] !== undefined ? parseInt(params[option]) : defaultValue);
+}
+
+(function() {
+
+    // manifest selector handler
+    document.getElementById("mpdSelector").onchange = function() {
+        stopUpdate();
+        var mpdUrl = document.getElementById("mpdSelector").value;
+        player.attachSource(mpdUrl);
+        startUpdate();
+    };
+
+    // quality switch button click handler
+    document.getElementById("videoQualitySwitcher").onclick = function() {
+        player.setAutoSwitchQualityFor('video', false);
+        player.setQualityFor('video', document.getElementById("presentationId").value);
+    };
+
+    var videoElement = document.getElementById("videoPlayer");
+    videoElement.addEventListener('error', function(ev) {
+        console.log(ev);
+        console.log(videoElement.error);
+    });
+
+    var p2pConfig = {
+        streamrootKey: "ry-tguzre2t",
+        debug: true
+    };
+    var urlParams = getURLParams(document.location.search);
+    var url = urlParams.mpd || mpdSelector.value;
+
+    player = createPlayer(videoElement, url, urlParams, p2pConfig);
+
+    mpdSelector.value = url;
+
+    startUpdate();
+
+})();

--- a/example/wrapper.html
+++ b/example/wrapper.html
@@ -57,85 +57,28 @@
         <div id="peerStat"/>
 
         <script>
-            (function() {
 
-                var updateIntervalId;
+            function createPlayer(videoElement, url, params, p2pConfig) {
 
-                function startUpdate() {
-                    updateIntervalId = setInterval(update, 1000);
-                }
+                var liveDelay = Number(params.liveDelay) || 30;
 
-                function stopUpdate() {
-                    clearInterval(updateIntervalId);
-                }
-
-                function update() {
-                    if (player.isReady()) {
-                        document.getElementById("liveDelay").innerHTML = "liveDelay=" + liveDelay;
-                        document.getElementById("bufferLength").innerHTML = "bufferLength=" + player.getBufferLength();
-                    }
-                }
-
-                function getURLParams(url) {
-                    if (!url) {
-                        return {};
-                    }
-
-                    var search = url.substring(1); //removing '?'
-                    var paramValueList = search.split("&");
-                    var params = {};
-                    paramValueList.forEach(function(entry){
-                        var paramValue = entry.split("=");
-                        if (entry) {
-                            params[paramValue[0]] = decodeURIComponent(paramValue[1]);
-                        }
-                    });
-
-                    return params;
-                }
-
-                // manifest selector handler
-                document.getElementById("mpdSelector").onchange = function() {
-                    stopUpdate();
-                    var mpdUrl = document.getElementById("mpdSelector").value;
-                    player.attachSource(mpdUrl);
-                    startUpdate();
-                };
-
-                // quality switch button click handler
-                document.getElementById("videoQualitySwitcher").onclick = function() {
-                    player.setAutoSwitchQualityFor('video', false);
-                    player.setQualityFor('video', document.getElementById("presentationId").value);
-                };
-
-                var urlParams = getURLParams(document.location.search);
+                var autoStart = parseURLOption(params, "autoStart", true);
+                var enableBOLA = parseURLOption(params, "enableBOLA", false);
 
                 var player = dashjs.MediaPlayer().create();
-                var p2pConfig = {
-                    streamrootKey: "ry-tguzre2t",
-                    debug: true
-                };
-                var liveDelay = Number(urlParams.liveDelay) || 30;
-                var dashjsWrapper = new DashjsWrapper(player, p2pConfig, liveDelay);
 
-                player.getDebug().setLogToBrowserConsole(urlParams.dashjsLog != "0");
+                var wrapper = new DashjsWrapper(player, p2pConfig, liveDelay);
 
-                var videoElementId = "videoPlayer";
-                var videoElement = document.getElementById(videoElementId);
+                player.getDebug().setLogToBrowserConsole(params.dashjsLog !== "0");
 
-                videoElement.addEventListener('error', function(ev) {
-                    console.log(ev);
-                    console.log(videoElement.error);
-                });
-
-                var url = urlParams.mpd || mpdSelector.value;
-                var autoStart = true;
+                player.enableBufferOccupancyABR(enableBOLA);
                 player.initialize(videoElement, url, autoStart);
 
-                mpdSelector.value = url;
+                return player;
+            }
 
-                startUpdate();
-            })();
         </script>
+        <script src="index.js"></script>
+
     </body>
 </html>

--- a/lib/DashjsBundle.js
+++ b/lib/DashjsBundle.js
@@ -10,7 +10,7 @@ function MediaPlayer(context, p2pConfig) {
 
     new DashjsWrapper(player, p2pConfig, liveDelay);
 
-  // Note: We will evaluate to player instance even when used as a constructor
+    // Note: We will evaluate to player instance even when used as a constructor
     return player;
 }
 

--- a/lib/FragmentLoaderClassProvider.js
+++ b/lib/FragmentLoaderClassProvider.js
@@ -109,7 +109,7 @@ function FragmentLoaderClassProvider(wrapper) {
 
             const sendHttpRequestMetric = function(isSuccess, responseCode) {
 
-                request.firstByteDate = request.firstByteDate || requestStartDate.requestStartDate;
+                request.firstByteDate = request.firstByteDate || request.requestStartDate;
                 request.requestEndDate = new Date();
 
                 metricsModel.addHttpRequest(
@@ -128,6 +128,9 @@ function FragmentLoaderClassProvider(wrapper) {
                     null, // responseHeaders // TODO: check if its really OK in all cases to pass null here
                     isSuccess ? traces : null // traces
                 );
+
+                var bitrate = 8 * totalBytesReceived / (request.requestEndDate.getTime() - request.firstByteDate.getTime());
+                console.log("bitrate: " + bitrate + ' kbit/s');
             };
 
             // TODO: check if we should use stats here

--- a/lib/FragmentLoaderClassProvider.js
+++ b/lib/FragmentLoaderClassProvider.js
@@ -100,6 +100,7 @@ function FragmentLoaderClassProvider(wrapper) {
             const requestStartDate = new Date();
             let lastTraceDate = requestStartDate;
             const traces = [];
+            let totalBytesReceived = 0;
             let lastTraceReceivedCount = 0;
             let remainingAttempts = mediaPlayerModel.getRetryAttemptsForType(request.type);
 
@@ -145,18 +146,17 @@ function FragmentLoaderClassProvider(wrapper) {
 
                 request.firstByteDate = request.firstByteDate || currentDate;
 
-                let bytesReceived = 0;
                 if (stats.cdnDownloaded) {
-                    bytesReceived += stats.cdnDownloaded;
+                    totalBytesReceived += stats.cdnDownloaded;
                 }
                 if (stats.p2pDownloaded) {
-                    bytesReceived += stats.p2pDownloaded;
+                    totalBytesReceived += stats.p2pDownloaded;
                 }
 
                 traces.push({
                     s: lastTraceDate,
                     d: currentDate.getTime() - lastTraceDate.getTime(),
-                    b: [bytesReceived ? bytesReceived - lastTraceReceivedCount : 0]
+                    b: [totalBytesReceived ? totalBytesReceived - lastTraceReceivedCount : 0]
                 });
 
                 lastTraceDate = currentDate;

--- a/lib/FragmentLoaderClassProvider.js
+++ b/lib/FragmentLoaderClassProvider.js
@@ -121,11 +121,11 @@ function FragmentLoaderClassProvider(wrapper) {
                     request.serviceLocation || null, // serviceLocation
                     request.range || null, // range
                     request.requestStartDate, // tRequest
-                    request.firstByteDate, // tResponce
+                    request.firstByteDate, // tResponse
                     request.requestEndDate, // tFinish
                     responseCode, // responseCode
                     request.duration, // mediaDuration
-                    null, // responseHeaders
+                    null, // responseHeaders // TODO: check if its really OK in all cases to pass null here
                     isSuccess ? traces : null // traces
                 );
             };

--- a/lib/FragmentLoaderClassProvider.js
+++ b/lib/FragmentLoaderClassProvider.js
@@ -229,9 +229,9 @@ function FragmentLoaderClassProvider(wrapper) {
         }
 
         instance = {
-            load: load,
-            abort: abort,
-            reset: reset
+            load,
+            abort,
+            reset
         };
 
         setup();

--- a/lib/FragmentLoaderClassProvider.js
+++ b/lib/FragmentLoaderClassProvider.js
@@ -160,7 +160,7 @@ function FragmentLoaderClassProvider(wrapper) {
                 });
 
                 lastTraceDate = currentDate;
-                lastTraceReceivedCount = bytesReceived;
+                lastTraceReceivedCount = totalBytesReceived;
 
                 eventBus.trigger(Events.LOADING_PROGRESS, {
                     request: request

--- a/lib/FragmentLoaderClassProvider.js
+++ b/lib/FragmentLoaderClassProvider.js
@@ -99,7 +99,6 @@ function FragmentLoaderClassProvider(wrapper) {
 
             const requestStartDate = new Date();
             let lastTraceDate = requestStartDate;
-            let isFirstProgress = true;
             const traces = [];
             let lastTraceReceivedCount = 0;
             let remainingAttempts = mediaPlayerModel.getRetryAttemptsForType(request.type);
@@ -144,10 +143,7 @@ function FragmentLoaderClassProvider(wrapper) {
 
                 let currentDate = new Date();
 
-                if (isFirstProgress) {
-                    isFirstProgress = false;
-                    request.firstByteDate = currentDate;
-                }
+                request.firstByteDate = request.firstByteDate || currentDate;
 
                 let bytesReceived = 0;
                 if (stats.cdnDownloaded) {

--- a/lib/FragmentLoaderClassProvider.js
+++ b/lib/FragmentLoaderClassProvider.js
@@ -93,21 +93,23 @@ function FragmentLoaderClassProvider(wrapper) {
                 return;
             }
 
+            // this need to be set already before calling `metricsModel.addHttpRequest`
+            // because the BOLA rule gets evaluated on progress events and needs this info
+            request.requestStartDate = new Date();
+
             const headers = _getHeadersForRequest(request);
             const segmentView = _getSegmentViewForRequest(request);
             const srRequest = _getSRRequest(request, headers);
 
-            const requestStartDate = new Date();
-            let lastTraceDate = requestStartDate;
             const traces = [];
+            let lastTraceDate = request.requestStartDate;
             let totalBytesReceived = 0;
             let lastTraceReceivedCount = 0;
             let remainingAttempts = mediaPlayerModel.getRetryAttemptsForType(request.type);
 
             const sendHttpRequestMetric = function(isSuccess, responseCode) {
 
-                request.requestStartDate = requestStartDate;
-                request.firstByteDate = request.firstByteDate || requestStartDate;
+                request.firstByteDate = request.firstByteDate || requestStartDate.requestStartDate;
                 request.requestEndDate = new Date();
 
                 metricsModel.addHttpRequest(


### PR DESCRIPTION
* eliminates redundancy of example page code
* adds `enableBOLA` option for query params
* eases adding more options generically
* fixes metrics reporting in FragmentLoader to allow for BOLA rule to function (requestStartDate needs to be set from start of request on the respective object)
* total bytes are counted within the scope of the request load closure