### PR TITLE
`console.log` should be `log`

### DIFF
--- a/lib/FragmentLoaderClassProvider.js
+++ b/lib/FragmentLoaderClassProvider.js
@@ -130,7 +130,7 @@ function FragmentLoaderClassProvider(wrapper) {
                 );
 
                 var bitrate = 8 * totalBytesReceived / (request.requestEndDate.getTime() - request.firstByteDate.getTime());
-                console.log("bitrate: " + bitrate + ' kbit/s');
+                log("bitrate: " + bitrate + ' kbit/s');
             };
 
             // TODO: check if we should use stats here


### PR DESCRIPTION
this slipped through on a recent feature