### PR TITLE
Specify handled tracks in FragmentLoader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This changelog's template come from [keepachangelog.com](http://keepachangelog.c
 ## [Dev]
 
 ## [Unreleased]
+### Added
+- Filter supported media types to handle only `audio` and `video`
 
 ## [1.7.0] - 2016-10-31
 ### Fixed

--- a/lib/FragmentLoaderClassProvider.js
+++ b/lib/FragmentLoaderClassProvider.js
@@ -13,6 +13,8 @@ function FragmentLoaderClassProvider(wrapper) {
     const FRAGMENT_LOADER_ERROR_NULL_REQUEST = 2;
     const FRAGMENT_LOADER_MESSAGE_NULL_REQUEST = 'request is null';
 
+    const HANDLED_TRACK_TYPES = ['audio', 'video'];
+
     function compensateTraceTimestamps(traces, requestDurationOffset) {
         let compensatedTraces = Object.assign([], traces);
         compensatedTraces.forEach((trace) => {
@@ -59,7 +61,8 @@ function FragmentLoaderClassProvider(wrapper) {
         }
 
         function _getSegmentViewForRequest(request) {
-            if (request.type !== "InitializationSegment") {
+            if (request.type !== "InitializationSegment" &&
+                HANDLED_TRACK_TYPES.indexOf(request.mediaInfo.type) >= 0) {
                 let trackView = new TrackView({
                     periodId: request.mediaInfo.streamInfo.index,
                     adaptationSetId: request.mediaInfo.index,


### PR DESCRIPTION
Only return segment view for requests concerning audio or video types. It allows us to filter what will come into the Peer-Agent.