### PR TITLE
Exposing peer agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,20 +152,16 @@ To see full sample code and extended possibilities of how to use this module, ta
 
 Specify your `streamrootKey` in the `p2pConfig` object. If you don't have it, go to [Streamroot's dashboard](http://dashboard.streamroot.io/) and sign up. It's free. You can check other `p2pConfig` options in the [documentation](https://streamroot.readme.io/docs/p2p-config).
 
-### Statistics
+### Peer agent instance exposure
 
 #### Bundle
 
-No statistics available yet.
+Not available yet.
 
 #### Wrapper
 
-A `stats` object is available on a `DashjsWrapper` instance and contains the following properties:
-
-- `cdn`: cdn downloaded (cumulated bytes).
-- `p2p`: p2p offloaded from cdn (cumulated bytes).
-- `upload`: p2p uploaded (cumulated bytes).
-- `peers`: real time connected peers count.
+A `peerAgent` public API is exposed on a`DashjsWrapper` instance -- `wrapper.peerAgent`.
+List of peerAgent's public API getters/setters is documented here https://streamroot.readme.io/docs/peeragent-class-reference.
 
 ### Run demos
 

--- a/example/bundle.html
+++ b/example/bundle.html
@@ -2,8 +2,6 @@
     <head>
         <title>Bundle example</title>
 
-        <script src="env.js"></script>
-
         <!-- streamroot-dash bundle -->
         <script src="../dist/bundle/dashjs-p2p-bundle.debug.js"></script>
 

--- a/example/env.js
+++ b/example/env.js
@@ -1,5 +1,0 @@
-window._MOBILE_ = false;
-window._ENVIRONMENT_ = 'development';
-window._DEBUG_ = true;
-window._TEST_ = false;
-window._VERSION_ = 'development';

--- a/example/wrapper.html
+++ b/example/wrapper.html
@@ -2,8 +2,6 @@
     <head>
         <title>Wrapper example</title>
 
-        <script src="env.js"></script>
-
         <!-- streamroot-dash wrapper -->
         <script src="../node_modules/dashjs/dist/dash.all.debug.js"></script>
         <script src="../dist/wrapper/dashjs-p2p-wrapper.debug.js"></script>

--- a/lib/DashjsWrapper.js
+++ b/lib/DashjsWrapper.js
@@ -1,16 +1,12 @@
 import DashjsWrapperPrivate from './DashjsWrapperPrivate';
+import PeerAgentAPI from './PeerAgentAPI';
 
 class DashjsWrapper {
 
     constructor(player, p2pConfig, liveDelay) {
         let wrapper = new DashjsWrapperPrivate(player, p2pConfig, liveDelay);
 
-        Object.defineProperty(this, "stats", {
-            get() {
-                console.info(wrapper.peerAgentModule);
-                return wrapper.peerAgentModule.stats;
-            }
-        });
+        this.peerAgent = PeerAgentAPI.get(wrapper);
     }
 
     static get version() {

--- a/lib/DashjsWrapper.js
+++ b/lib/DashjsWrapper.js
@@ -9,6 +9,10 @@ class DashjsWrapper {
         this.peerAgent = PeerAgentAPI.get(wrapper);
     }
 
+    get version() {
+        return DashjsWrapper.version;
+    }
+
     static get version() {
         return DashjsWrapperPrivate.version;
     }

--- a/lib/DashjsWrapperPrivate.js
+++ b/lib/DashjsWrapperPrivate.js
@@ -63,10 +63,6 @@ class DashjsWrapperPrivate {
         );
     }
 
-    get peerAgentModule() {
-        return this._peerAgentModule;
-    }
-
     get manifest() {
         return this._manifest;
     }
@@ -86,7 +82,7 @@ class DashjsWrapperPrivate {
             this._liveDelay
         );
 
-        this._peerAgentModule = new DashjsWrapperPrivate.StreamrootPeerAgentModule(
+        this.peerAgentModule = new DashjsWrapperPrivate.StreamrootPeerAgentModule(
             this._playerInterface,
             this._manifest.url,
             new MediaMap(manifestHelper),
@@ -98,7 +94,7 @@ class DashjsWrapperPrivate {
 
         try {
             let mediaElement = this._player.getVideoElement(); // Throws if media element is not attached, thus the try / catch block
-            this._peerAgentModule.setMediaElement(mediaElement);
+            this.peerAgentModule.setMediaElement(mediaElement);
         } catch (e) {
             // There is no event on dash.js notifying the moment where the video is attached: simply warn in the console
             console.warn("Tried to access media element before it was set");
@@ -106,8 +102,8 @@ class DashjsWrapperPrivate {
     }
 
     dispose() {
-        if (this._peerAgentModule) {
-            this._peerAgentModule.dispose();
+        if (this.peerAgentModule) {
+            this.peerAgentModule.dispose();
         }
 
         if (this._playerInterface) {

--- a/lib/PeerAgentAPI.js
+++ b/lib/PeerAgentAPI.js
@@ -1,0 +1,35 @@
+function getPeerAgentAPI(privateWrapper) {
+
+    const peerAgentAPI = {
+
+        get stats() {
+            return privateWrapper.peerAgentModule.stats;
+        },
+
+        get version() {
+            return privateWrapper.peerAgentModule.version;
+        },
+
+        get isP2PEnabled() {
+            return privateWrapper.peerAgentModule.isP2PEnabled;
+        },
+
+        get p2pDownloadOn() {
+            return privateWrapper.peerAgentModule.p2pDownloadOn;
+        },
+        set p2pDownloadOn(value) {
+            privateWrapper.peerAgentModule.p2pDownloadOn = value;
+        },
+
+        get p2pUploadOn() {
+            return privateWrapper.peerAgentModule.p2pUploadOn;
+        },
+        set p2pUploadOn(value) {
+            privateWrapper.peerAgentModule.p2pUploadOn = value;
+        },
+    };
+
+    return peerAgentAPI;
+}
+
+export default { get: getPeerAgentAPI };

--- a/test/PeerAgentAPI.js
+++ b/test/PeerAgentAPI.js
@@ -1,0 +1,66 @@
+import PeerAgentAPI from '../lib/PeerAgentAPI';
+
+const peerAgentMock = {
+    isP2PEnabled: true,
+    p2pDownloadOn: true,
+    stats: {},
+    version: 'fakeVersion',
+    p2pUploadOn: true,
+    dispose: () => {
+
+    }
+};
+
+const privateWrapperMock = {
+    peerAgentModule: peerAgentMock,
+};
+
+describe('PeerAgentAPI', () => {
+    it('should expose defined list of properties only', () => {
+        const peerAgentAPI = PeerAgentAPI.get(privateWrapperMock);
+
+        peerAgentAPI.should.eql({
+            stats: peerAgentMock.stats,
+            version: peerAgentMock.version,
+            isP2PEnabled: peerAgentMock.isP2PEnabled,
+            p2pDownloadOn: peerAgentMock.p2pDownloadOn,
+            p2pUploadOn: peerAgentMock.p2pUploadOn,
+        });
+    });
+
+    it('should expose stats correctly and throw if trying to set its value', () => {
+        const peerAgentAPI = PeerAgentAPI.get(privateWrapperMock);
+
+        peerAgentAPI.stats.should.equal(peerAgentMock.stats);
+        (() => { peerAgentAPI.stats = {}; }).should.throw();
+    });
+
+    it('should expose correct peer agent version', () => {
+        const peerAgentAPI = PeerAgentAPI.get(privateWrapperMock);
+
+        peerAgentAPI.version.should.equal(peerAgentMock.version);
+    });
+
+    it('should expose isP2PEnabled correctly and throw if trying to set its value', () => {
+        const peerAgentAPI = PeerAgentAPI.get(privateWrapperMock);
+
+        peerAgentAPI.isP2PEnabled.should.equal(peerAgentMock.isP2PEnabled);
+        (() => { peerAgentAPI.isP2PEnabled = false; }).should.throw();
+    });
+
+    it('should expose p2pDownloadOn correctly and allow setting its value', () => {
+        const peerAgentAPI = PeerAgentAPI.get(privateWrapperMock);
+
+        peerAgentAPI.p2pDownloadOn.should.equal(peerAgentMock.p2pDownloadOn);
+        peerAgentAPI.p2pDownloadOn = false;
+        peerAgentAPI.p2pDownloadOn.should.equal(false);
+    });
+
+    it('should expose p2pUploadOn correctly and allow setting its value', () => {
+        const peerAgentAPI = PeerAgentAPI.get(privateWrapperMock);
+
+        peerAgentAPI.p2pUploadOn.should.equal(peerAgentMock.p2pUploadOn);
+        peerAgentAPI.p2pUploadOn = false;
+        peerAgentAPI.p2pUploadOn.should.equal(false);
+    });
+});


### PR DESCRIPTION
PR story https://www.pivotaltracker.com/story/show/134849477

Removed peer agent related getters/setters from wrapper instance.
Created peer agent public API object, that is exposed on wrapper instance through getter `wrapper.peerAgent`.