### PR TITLE
Fixing peer agent undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This changelog's template come from [keepachangelog.com](http://keepachangelog.com/). When editing this document, please follow the convention specified there.
 
 ## [Dev]
-### Fixed
-- Wrapper exception when accessing undefined peerAgentModule.
 
 ## [Unreleased]
+### Fixed
+- Wrapper exception when accessing undefined peerAgentModule.
 
 ## [1.9.0] - 2017-01-10
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This changelog's template come from [keepachangelog.com](http://keepachangelog.com/). When editing this document, please follow the convention specified there.
 
 ## [Dev]
+### Fixed
+- Wrapper exception when accessing undefined peerAgentModule.
 
 ## [Unreleased]
 

--- a/lib/DashjsWrapperPrivate.js
+++ b/lib/DashjsWrapperPrivate.js
@@ -63,6 +63,10 @@ class DashjsWrapperPrivate {
         );
     }
 
+    get peerAgentModule() {
+        return this._peerAgentModule;
+    }
+
     get manifest() {
         return this._manifest;
     }
@@ -82,7 +86,7 @@ class DashjsWrapperPrivate {
             this._liveDelay
         );
 
-        this.peerAgentModule = new DashjsWrapperPrivate.StreamrootPeerAgentModule(
+        this._peerAgentModule = new DashjsWrapperPrivate.StreamrootPeerAgentModule(
             this._playerInterface,
             this._manifest.url,
             new MediaMap(manifestHelper),
@@ -94,7 +98,7 @@ class DashjsWrapperPrivate {
 
         try {
             let mediaElement = this._player.getVideoElement(); // Throws if media element is not attached, thus the try / catch block
-            this.peerAgentModule.setMediaElement(mediaElement);
+            this._peerAgentModule.setMediaElement(mediaElement);
         } catch (e) {
             // There is no event on dash.js notifying the moment where the video is attached: simply warn in the console
             console.warn("Tried to access media element before it was set");
@@ -102,8 +106,8 @@ class DashjsWrapperPrivate {
     }
 
     dispose() {
-        if (this.peerAgentModule) {
-            this.peerAgentModule.dispose();
+        if (this._peerAgentModule) {
+            this._peerAgentModule.dispose();
         }
 
         if (this._playerInterface) {


### PR DESCRIPTION
This PR fixes broken wrapper workflow.

**What happened**: in some previous commit `peerAgentModule` getter was removed, and peerAgent var was exposed as public instead. This lead to an exception, because wrapper class is passed to our custom fragment loader before peer agent is initialized, which leads to peer agent being stored in fragment loader as `undefined`.

**How it was fixed**: I returned the getter back, so when fragment loader needs peer agent, it accesses it via getter, which at that time returns initialized peer agent reference.