### PR TITLE
Ruby script to generate wrapper example pages with specific Dash.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This changelog's template come from [keepachangelog.com](http://keepachangelog.c
 
 ## [Dev]
 
+### Added
+- Ruby script to generate example wrapper page with a specific version of Dash.js.
+
 ### Changed
 - Replace debug tools in example page with `public-graph`.
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,16 @@ player.initialize(videoElement, manifestURL, autoStart);
 
 To see full sample code and extended possibilities of how to use this module, take a look at the code in the `example` directory.
 
+#### Wrapper with specific release of Dash.js from CDN
+
+If you want to test the wrapper with a specific version of Dash.js, you could generate an example page with a specific version of Dash.js using:
+
+```
+npm run generate_example -- <Dash.js version>
+```
+
+For example `npm run generate_example -- 2.4.0` will generate `example2.4.0.wrapper.html` with Dash.js `2.4.0` instead of the bundled Dash.js `2.3.0`.
+
 ### Configuration
 
 Specify your `streamrootKey` in the `p2pConfig` object. If you don't have it, go to [Streamroot's dashboard](http://dashboard.streamroot.io/) and sign up. It's free. You can check other `p2pConfig` options in the [documentation](https://streamroot.readme.io/docs/p2p-config).

--- a/generate_example_wrapper_page.rb
+++ b/generate_example_wrapper_page.rb
@@ -1,0 +1,19 @@
+#!/usr/bin/ruby
+
+# Path constants
+EXAMPLE_DIR = "./example"
+TEMPLATE_FILENAME = "wrapper.html"
+TEMPLATE_FILE = File.join(EXAMPLE_DIR, TEMPLATE_FILENAME)
+CDN_TEMPLATE = "https://cdnjs.cloudflare.com/ajax/libs/dashjs/%s/dash.all.debug.js"
+
+input_array = ARGV
+
+if input_array.length != 1 or input_array[0] == "-h" or input_array[0] == "--help"
+  puts "Usage: generate_example_wrapper_page.rb <Dash.js version>"
+else
+  dashjs_version = input_array[0]
+  html = IO.read(TEMPLATE_FILE)
+  html_modded = html.gsub(/\.\.\/node_modules\/dashjs\/dist\/dash\.all\.debug\.js/, CDN_TEMPLATE % dashjs_version)
+  File.write(File.join(EXAMPLE_DIR, "dashjs#{dashjs_version}.#{TEMPLATE_FILENAME}"), html_modded)
+  puts "Generated wrapper test page with Dash.js #{dashjs_version}"
+end

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "lint": "./node_modules/.bin/eslint lib/ test/",
     "lint-fix": "./node_modules/.bin/eslint --fix lib/ test/",
     "test": "./node_modules/.bin/mocha --require mochahook",
-    "wrapper_dev": "webpack --progress --watch --config webpack/webpack.wrapper.dev.babel.js"
+    "wrapper_dev": "webpack --progress --watch --config webpack/webpack.wrapper.dev.babel.js",
+    "generate_example": "ruby generate_example_wrapper_page.rb"
   },
   "dependencies": {
     "codem-isoboxer": "0.2.2",


### PR DESCRIPTION
I used this as a testing tool when fixing Dash.js 2.4 issue but it would be useful to have for future testing and/or debugging the wrapper. For example: `./generate_example_wrapper_page.rb 2.3.0` will generate `example/dashjs2.3.0.wrapper.html`.