### PR TITLE
Better fix for Dash.js 2.4 event naming change

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This module wraps [`dash.js`](https://github.com/Dash-Industry-Forum/dash.js) to
 It provides a bundle that extends the [`dash.js`](https://github.com/Dash-Industry-Forum/dash.js) `MediaPlayer` constructor to create a fully configured player which will use the Streamroot P2P module, giving you the exact same API.
 You can integrate this bundle with minimal changes in your application. **The bundled version of dash.js is v2.3.0**.
 
-It also provides a wrapper that allows you to create/configure a player with a specific version of [`dash.js`](https://github.com/Dash-Industry-Forum/dash.js). **Minimum supported version of dash.js is v2.2.0. Dash.js 2.4+ is not supported at the moment.**
+It also provides a wrapper that allows you to create/configure a player with a specific version of [`dash.js`](https://github.com/Dash-Industry-Forum/dash.js). **Minimum supported version of dash.js is v2.2.0.**
 
 ### Install via npm
 You can install the artifacts distributed as NPM modules:

--- a/lib/DashjsWrapperPrivate.js
+++ b/lib/DashjsWrapperPrivate.js
@@ -55,18 +55,13 @@ class DashjsWrapperPrivate {
             true
         );
 
-        // From 2.3 -> 2.4 the event name is changed to be camel-cased so we need to subscribe to 2 different events (and luckily they are mutually-exclusive)
-        const MANIFEST_LOADED_23 = 'manifestloaded';
-        const MANIFEST_LOADED_24 = 'manifestLoaded';
+        // Throws if there is no dashjs context available
+        if (typeof dashjs === 'undefined') {
+            throw new Error("dashjs context undefined.");
+        }
 
         this._player.on(
-            MANIFEST_LOADED_23,
-            this._onManifestLoaded,
-            this
-        );
-
-        this._player.on(
-            MANIFEST_LOADED_24,
+            dashjs.MediaPlayer.events.MANIFEST_LOADED,
             this._onManifestLoaded,
             this
         );


### PR DESCRIPTION
Putting "magic strings" for event name is prone to failure when such a name change happens again. A better way to fix this problem, since the constant variable name is the same, only the value changed, is to get its value on run-time. The value of this constant is accessible in `window.dashjs.MediaPlayer.events`, by extracting this the correct event name for the page-included Dash.js version could be obtained.