### PR TITLE
Hotfix for playback crash in Firefox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This changelog's template come from [keepachangelog.com](http://keepachangelog.c
 
 ## [Dev]
 
+### Fixed
+- Fix playback hanging on Firefox.
+
 ## [Unreleased]
 
 ## [1.10.0] - 2017-02-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,10 @@ This changelog's template come from [keepachangelog.com](http://keepachangelog.c
 
 ## [Dev]
 
+## [Unreleased]
+
 ### Fixed
 - Fix playback hanging on Firefox.
-
-## [Unreleased]
 
 ## [1.10.0] - 2017-02-08
 

--- a/example/bundle.html
+++ b/example/bundle.html
@@ -7,7 +7,7 @@
     </head>
     <body>
 
-        <a href="wrapper.html">Go to wrapper example</a><br><br>
+        <a href="wrapper.html">Go to wrapper example</a>
 
         <div>
             <div id="mainfestSelection">

--- a/example/bundle.html
+++ b/example/bundle.html
@@ -10,7 +10,7 @@
         <a href="wrapper.html">Go to wrapper example</a><br><br>
 
         <div>
-            <div id="mainfestSelection" />
+            <div id="mainfestSelection">
                 <select id="mpdSelector" name="mpdSelector">
                     <option value="http://wowza-test.streamroot.io/liveOrigin/sintel-live.smil/manifest.mpd">Streamroot live test stream</option>
                     <option value="http://wowza.streamroot.io/vodOriginSite/tears_of_steel720p.mp4/manifest.mpd">ToS (VoD, 1 video)</option>

--- a/example/wrapper.html
+++ b/example/wrapper.html
@@ -11,7 +11,7 @@
         <a href="bundle.html">Go to bundle example</a><br><br>
 
         <div>
-            <div id="mainfestSelection" />
+            <div id="mainfestSelection">
                 <select id="mpdSelector" name="mpdSelector">
                     <option value="http://wowza-test.streamroot.io/liveOrigin/sintel-live.smil/manifest.mpd">Streamroot live test stream</option>
                     <option value="http://wowza.streamroot.io/vodOriginSite/tears_of_steel720p.mp4/manifest.mpd">ToS (VoD, 1 video)</option>

--- a/example/wrapper.html
+++ b/example/wrapper.html
@@ -8,7 +8,7 @@
     </head>
     <body>
 
-        <a href="bundle.html">Go to bundle example</a><br><br>
+        <a href="bundle.html">Go to bundle example</a>
 
         <div>
             <div id="mainfestSelection">

--- a/lib/FragmentLoaderClassProvider.js
+++ b/lib/FragmentLoaderClassProvider.js
@@ -185,9 +185,9 @@ function FragmentLoaderClassProvider(wrapper) {
 
                 let bytesLoaded = stats.cdnDownloaded + stats.p2pDownloaded;
 
-                if (event.lengthComputable) {
+                if (stats.lengthComputable) {
                     request.bytesLoaded = bytesLoaded;
-                    request.bytesTotal = event.total;
+                    request.bytesTotal = stats.total;
                 }
 
                 traces.push({

--- a/webpack/webpack.bundle.dev.babel.js
+++ b/webpack/webpack.bundle.dev.babel.js
@@ -15,6 +15,8 @@ export default Object.assign(baseConfig, {
         filename: 'dashjs-p2p-bundle.js',
     },
 
+    devtool: 'source-map',
+
     plugins: [
         new webpack.DefinePlugin({
             _VERSION_: JSON.stringify(version),

--- a/webpack/webpack.wrapper.dev.babel.js
+++ b/webpack/webpack.wrapper.dev.babel.js
@@ -15,6 +15,8 @@ export default Object.assign(baseConfig, {
         filename: 'dashjs-p2p-wrapper.js',
     },
 
+    devtool: 'source-map',
+
     plugins: [
         new webpack.DefinePlugin({
             _VERSION_: JSON.stringify(version),


### PR DESCRIPTION
In [this file](https://github.com/streamroot/dashjs-p2p-wrapper/blob/73202dfb41bae706ac372bca212b71fed6eca04e/lib/FragmentLoaderClassProvider.js#L188) the undefined variable `event` is used which should be `stats`. Looks like this function is not invoked on Chrome but it does and throws exception on Firefox causing playback to crash. I propose a hotfix to deal with this problem. This resolves [this bug](https://www.pivotaltracker.com/n/projects/1597593/stories/139376527).