### PR TITLE
Adding `type` field to TrackView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This changelog's template come from [keepachangelog.com](http://keepachangelog.c
 ## [1.11.0] - 2017-03-13
 ### Added
 - Catching fragment loading abortion(due to unsufficient bandwidth) and notifying peer agent about that.
+- `type` property to TrackView.
 
 ### Changed
 - Simplified peer agent event handling.

--- a/lib/FragmentLoaderClassProvider.js
+++ b/lib/FragmentLoaderClassProvider.js
@@ -66,7 +66,8 @@ function FragmentLoaderClassProvider(wrapper) {
                 let trackView = new TrackView({
                     periodId: request.mediaInfo.streamInfo.index,
                     adaptationSetId: request.mediaInfo.index,
-                    representationId: request.quality
+                    representationId: request.quality,
+                    type: request.mediaInfo.type
                 });
 
                 return new SegmentView({

--- a/lib/ManifestHelper.js
+++ b/lib/ManifestHelper.js
@@ -74,7 +74,8 @@ class ManifestHelper {
                 tracks[type] = new TrackView({
                     periodId: currentTrack.streamInfo.index,
                     adaptationSetId: currentTrack.index,
-                    representationId: quality
+                    representationId: quality,
+                    type
                 });
             }
         }
@@ -102,7 +103,8 @@ class ManifestHelper {
                                 new TrackView({
                                     periodId: period.index,
                                     adaptationSetId: adaptationSet.index,
-                                    representationId: i
+                                    representationId: i,
+                                    type
                                 })
                             );
                         }

--- a/lib/PlayerInterface.js
+++ b/lib/PlayerInterface.js
@@ -141,7 +141,8 @@ class PlayerInterface extends EventEmitter {
         tracks[mediaType] = new TrackView({
             periodId: streamInfo.index,
             adaptationSetId: this._player.getCurrentTrackFor(mediaType).index,
-            representationId: Number(newQuality)
+            representationId: Number(newQuality),
+            mediaType
         });
 
         this.emit(ExternalEvents.TRACK_CHANGE_EVENT, tracks);

--- a/lib/PlayerInterface.js
+++ b/lib/PlayerInterface.js
@@ -127,7 +127,9 @@ class PlayerInterface extends EventEmitter {
 
     _onStreamInitialized() {
         // As we handle this event once per manifest, we unsubscribe from it
-        this._player.off(dashjs.MediaPlayer.events.STREAM_INITIALIZED, this._onStreamInitialized, this);
+        // Should be done in this async way, otherwise dash.js hit some hidden error, a
+        // And dynamic stream switching becomes broken.
+        setTimeout(this._player.off, 0, STREAM_INITIALIZED_EVENT, this._onStreamInitialized, this);
 
         // And subscribe to quality switch event instead
         this._player.on(QUALITY_CHANGE_EVENT, this._onQualityChanged, this);

--- a/lib/TrackView.js
+++ b/lib/TrackView.js
@@ -4,6 +4,7 @@ class TrackView {
         this.periodId = obj.periodId;
         this.adaptationSetId = obj.adaptationSetId;
         this.representationId = obj.representationId;
+        this.type = obj.type;
     }
 
     static makeIDString(periodId, adaptationSetId, representationId) {


### PR DESCRIPTION
Though it's declared as optional in integration doc for v4, it's already used(if supported by wrapper) by peer-agent. `hlsjs-p2p-wrapper` implemented this(`type` is hardcoded to `video`) already, now it's `dashjs-p2p-wrapper` turn.

For example:
1. Here https://github.com/streamroot/peer-agent/blob/dev/app/js/p2p/SRModule.js#L111.
1. Here https://github.com/streamroot/peer-agent/blob/dev/app/js/p2p/stats/MediaStats.js#L29.
