### PR TITLE
Prevent fragment load retry after abort 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This changelog's template come from [keepachangelog.com](http://keepachangelog.c
 ## [Dev]
 
 ## [Unreleased]
+### Fixed
+- Prevent fragment load retry after abort (could cause a fragment of a previous bitrate to be appended after bitrate switch, causing decode error)
 
 ## [1.11.10] - 2017-05-12
 ### Fixed

--- a/lib/FragmentLoaderClassProvider.js
+++ b/lib/FragmentLoaderClassProvider.js
@@ -64,7 +64,8 @@ function FragmentLoaderClassProvider(wrapper) {
             peerAgent,
             _loader,
             retryTimers,
-            downloadErrorToRequestTypeMap;
+            downloadErrorToRequestTypeMap,
+            remainingAttempts;
 
         function setup() {
             peerAgent = wrapper.peerAgentModule;
@@ -153,7 +154,7 @@ function FragmentLoaderClassProvider(wrapper) {
 
             let lastTraceDate = request.requestStartDate;
             let lastTraceReceivedCount = 0;
-            let remainingAttempts = mediaPlayerModel.getRetryAttemptsForType(request.type);
+            remainingAttempts = mediaPlayerModel.getRetryAttemptsForType(request.type);
 
             const sendHttpRequestMetric = function(isSuccess, responseCode) {
                 metricsModel.addHttpRequest(
@@ -255,6 +256,7 @@ function FragmentLoaderClassProvider(wrapper) {
         }
 
         function abort() {
+            remainingAttempts = 0; // Prevent any retry
             retryTimers.forEach(t => clearTimeout(t));
             retryTimers = [];
 


### PR DESCRIPTION
Could cause a fragment of a previous bitrate to be appended after bitrate switch, causing decode error