### PR TITLE
Fix HttpRequestMetric format: was expecting string for response headers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This changelog's template come from [keepachangelog.com](http://keepachangelog.c
 ## [Dev]
 
 ## [Unreleased]
+### Fixed
+- HttpRequestMetric format in our fragment loader: was expecting string for response headers. Returning null could break some 3rd party plugins
 
 ## [1.11.13] - 2017-05-31
 ### Fixed

--- a/lib/FragmentLoaderClassProvider.js
+++ b/lib/FragmentLoaderClassProvider.js
@@ -156,7 +156,7 @@ function FragmentLoaderClassProvider(wrapper) {
             let lastTraceReceivedCount = 0;
             remainingAttempts = mediaPlayerModel.getRetryAttemptsForType(request.type);
 
-            const sendHttpRequestMetric = function(isSuccess, responseCode) {
+            const sendHttpRequestMetric = function(isSuccess, responseCode, contentLength) {
                 metricsModel.addHttpRequest(
                     request.mediaType, // mediaType
                     null, // tcpId
@@ -170,14 +170,16 @@ function FragmentLoaderClassProvider(wrapper) {
                     request.requestEndDate, // tFinish
                     responseCode, // responseCode
                     request.duration, // mediaDuration
-                    null, // responseHeaders // TODO: check if its really OK in all cases to pass null here
+                    "Content-Length: " + contentLength, // responseHeaders
                     isSuccess ? traces : null // traces
                 );
             };
 
             const onSuccess = function(segmentData, stats) {
+                let contentLength = stats.cdnDownloaded + stats.p2pDownloaded;
+
                 modifyRequestDates(stats, request, traces);
-                sendHttpRequestMetric(true, 200);
+                sendHttpRequestMetric(true, 200, contentLength);
 
                 eventBus.trigger(Events.LOADING_COMPLETED, {
                     request: request,


### PR DESCRIPTION
Returning null could break some 3rd party plugins