### PR TITLE
Make sure we don't call any FragmentLoader callback once a request is aborted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This changelog's template come from [keepachangelog.com](http://keepachangelog.c
 ## [Dev]
 
 ## [Unreleased]
+### Fixed
+- Make sure we don't call any FragmentLoader callback once a request is aborted (we used to call the downloadError callback)
 
 ## [1.11.14] - 2017-05-31
 ### Fixed

--- a/lib/FragmentLoaderClassProvider.js
+++ b/lib/FragmentLoaderClassProvider.js
@@ -66,7 +66,7 @@ function FragmentLoaderClassProvider(wrapper) {
             retryTimers,
             downloadErrorToRequestTypeMap,
             remainingAttempts,
-            _aborted = false;
+            _aborted;
 
         function setup() {
             peerAgent = wrapper.peerAgentModule;
@@ -131,6 +131,9 @@ function FragmentLoaderClassProvider(wrapper) {
         }
 
         function load(request) {
+            remainingAttempts = mediaPlayerModel.getRetryAttemptsForType(request.type);
+            _aborted = false;
+
 
             if (!request) {
                 eventBus.trigger(Events.LOADING_COMPLETED, {
@@ -155,7 +158,6 @@ function FragmentLoaderClassProvider(wrapper) {
 
             let lastTraceDate = request.requestStartDate;
             let lastTraceReceivedCount = 0;
-            remainingAttempts = mediaPlayerModel.getRetryAttemptsForType(request.type);
 
             const sendHttpRequestMetric = function(isSuccess, responseCode, contentLength) {
                 metricsModel.addHttpRequest(

--- a/lib/FragmentLoaderClassProvider.js
+++ b/lib/FragmentLoaderClassProvider.js
@@ -65,7 +65,8 @@ function FragmentLoaderClassProvider(wrapper) {
             _loader,
             retryTimers,
             downloadErrorToRequestTypeMap,
-            remainingAttempts;
+            remainingAttempts,
+            _aborted = false;
 
         function setup() {
             peerAgent = wrapper.peerAgentModule;
@@ -176,6 +177,10 @@ function FragmentLoaderClassProvider(wrapper) {
             };
 
             const onSuccess = function(segmentData, stats) {
+                if (_aborted) {
+                    return;
+                }
+
                 let contentLength = stats.cdnDownloaded + stats.p2pDownloaded;
 
                 modifyRequestDates(stats, request, traces);
@@ -189,6 +194,9 @@ function FragmentLoaderClassProvider(wrapper) {
             };
 
             const onProgress = function(stats) {
+                if (_aborted) {
+                    return;
+                }
 
                 let currentDate = new Date();
 
@@ -216,6 +224,9 @@ function FragmentLoaderClassProvider(wrapper) {
             };
 
             const onError = function(httpError) {
+                if (_aborted) {
+                    return;
+                }
                 sendHttpRequestMetric(false, httpError.status);
 
                 if (remainingAttempts > 0) {
@@ -258,6 +269,8 @@ function FragmentLoaderClassProvider(wrapper) {
         }
 
         function abort() {
+            _aborted = true;
+
             remainingAttempts = 0; // Prevent any retry
             retryTimers.forEach(t => clearTimeout(t));
             retryTimers = [];


### PR DESCRIPTION
Dash.js unregisters all xhr callbacks before aborting a request. https://github.com/Dash-Industry-Forum/dash.js/blob/development/src/streaming/XHRLoader.js#L278-L281

Just implemented the equivalent in our wrapper