### PR TITLE
Detect when player is reset and dispose the wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This changelog's template come from [keepachangelog.com](http://keepachangelog.c
 ## [Dev]
 
 ## [Unreleased]
+### Fixed
+- Detect when player is reset and dispose the wrapper.
 
 ## [1.11.15] - 2017-06-02
 ### Fixed

--- a/lib/DashjsWrapperPrivate.js
+++ b/lib/DashjsWrapperPrivate.js
@@ -129,11 +129,6 @@ class DashjsWrapperPrivate {
     }
 
     _onManifestLoaded({data}) {
-        if (!data) {
-            this.dispose();
-            return;
-        }
-
         if (!this._manifest) {
             this.initialize(data);
             return;

--- a/lib/DashjsWrapperPrivate.js
+++ b/lib/DashjsWrapperPrivate.js
@@ -7,6 +7,7 @@ import StreamrootPeerAgentModule from 'streamroot-p2p';
 import DashjsInternals from './DashjsInternals';
 
 const INTEGRATION_VERSION = 'v1';
+const STREAM_TEARDOWN_COMPLETE = 'streamTeardownComplete';
 
 let streamrootPeerAgentModuleClass = StreamrootPeerAgentModule;
 
@@ -65,6 +66,8 @@ class DashjsWrapperPrivate {
             this._onManifestLoaded,
             this
         );
+
+        this.player.on(STREAM_TEARDOWN_COMPLETE, this.dispose, this);
     }
 
     get peerAgentModule() {


### PR DESCRIPTION
Using dash.js core event `STREAM_TEARDOWN_COMPLETE` as per: https://github.com/Dash-Industry-Forum/dash.js/issues/2005