### PR TITLE
Using MediaPlayer.events.STREAM_TEARDOWN_COMPLETE from enum if available

### DIFF
--- a/lib/DashjsWrapperPrivate.js
+++ b/lib/DashjsWrapperPrivate.js
@@ -7,7 +7,7 @@ import StreamrootPeerAgentModule from 'streamroot-p2p';
 import DashjsInternals from './DashjsInternals';
 
 const INTEGRATION_VERSION = 'v1';
-const STREAM_TEARDOWN_COMPLETE = 'streamTeardownComplete';
+const STREAM_TEARDOWN_COMPLETE = dashjs.MediaPlayer.events.STREAM_TEARDOWN_COMPLETE || 'streamTeardownComplete';
 
 let streamrootPeerAgentModuleClass = StreamrootPeerAgentModule;
 


### PR DESCRIPTION
Will be available in future dash.js version (see https://github.com/Dash-Industry-Forum/dash.js/pull/2038)